### PR TITLE
Add Mapset Total Drain Time Requirement to Ranking Criteria

### DIFF
--- a/wiki/Ranking_Criteria/en.md
+++ b/wiki/Ranking_Criteria/en.md
@@ -17,7 +17,7 @@ This criteria may change in the future, due to increasing map requests and BAT m
 
 ### Spread
 
-- **Mapsets should have a total drain time over 80 seconds (1 minute 20 seconds).**
+- **Mapsets should have a total drain time over 90 seconds (1 minute and 30 seconds).**
 - **Difficulty names must have progression.**
   - Easy -> Normal -> Hard -> Insane -> Expert is default.
   - Logical naming schemes like Seed -> Sprout -> Tree are okay too.

--- a/wiki/Ranking_Criteria/en.md
+++ b/wiki/Ranking_Criteria/en.md
@@ -17,6 +17,7 @@ This criteria may change in the future, due to increasing map requests and BAT m
 
 ### Spread
 
+- **Mapsets should have a total drain time over 80 seconds (1 minute 20 seconds).**
 - **Difficulty names must have progression.**
   - Easy -> Normal -> Hard -> Insane -> Expert is default.
   - Logical naming schemes like Seed -> Sprout -> Tree are okay too.

--- a/wiki/Ranking_Criteria/en.md
+++ b/wiki/Ranking_Criteria/en.md
@@ -17,7 +17,7 @@ This criteria may change in the future, due to increasing map requests and BAT m
 
 ### Spread
 
-- **Mapsets should have a total drain time over 90 seconds (1 minute and 30 seconds).**
+- **Mapsets must have a total drain time over 90 seconds (1 minute and 30 seconds).**
 - **Difficulty names must have progression.**
   - Easy -> Normal -> Hard -> Insane -> Expert is default.
   - Logical naming schemes like Seed -> Sprout -> Tree are okay too.

--- a/wiki/Ranking_Criteria/en.md
+++ b/wiki/Ranking_Criteria/en.md
@@ -17,7 +17,7 @@ This criteria may change in the future, due to increasing map requests and BAT m
 
 ### Spread
 
-- **Mapsets must have a total drain time over 90 seconds (1 minute and 30 seconds).**
+- **Mapsets must have a total drain time of at least 90 seconds (1 minute and 30 seconds).**
 - **Difficulty names must have progression.**
   - Easy -> Normal -> Hard -> Insane -> Expert is default.
   - Logical naming schemes like Seed -> Sprout -> Tree are okay too.


### PR DESCRIPTION
All mapsets ranked on Titanic will now require a total drain time of 90 seconds. This is in addition to the minimum length of the song being 30 seconds. That means if you are mapping a 30 second song you need at least 3 difficulties. If you are mapping a TV size song you will need at least 2 difficulties.