### PR TITLE
Add ame to `Verifed Users`

### DIFF
--- a/wiki/People/Verified_Users/en.md
+++ b/wiki/People/Verified_Users/en.md
@@ -26,3 +26,4 @@ User | Bancho account
 [Cl8n](https://osu.titanic.sh/u/3004) | [clayton](https://osu.ppy.sh/users/3666350)
 [Sonnyc](https://osu.titanic.sh/u/3041) | [Sonnyc](https://osu.ppy.sh/users/11771)
 [Alvarobot](https://osu.titanic.sh/u/3147) | [A L E P H](https://osu.ppy.sh/users/6735738)
+[ame](https://osu.titanic.sh/u/3164) | Restricted


### PR DESCRIPTION
They are currently restricted from bancho but here is the link to their account incase we want to replace it with that /shrug

https://osu.ppy.sh/u/11685498

they also have a mamestagram account we could link to but I want to hear some thoughts first

https://web.mamesosu.net/profile/6628/std
twitter: https://nitter.net/_ktr1hc