### PR TITLE
Change stream link for SDG to YT VOD

### DIFF
--- a/wiki/History/Tournaments/Sudden_Death_Gauntlet/en.md
+++ b/wiki/History/Tournaments/Sudden_Death_Gauntlet/en.md
@@ -43,7 +43,7 @@ Sudden Death Gauntlet was run by a few community members.
 
 - [Forum thread](https://osu.titanic.sh/forum/27/t/2666/)
 - [Challonge bracket](https://challonge.com/ap1izprr)
-- [Livestream](https://twitch.tv/ferret_irl)
+- [Stream VOD](https://youtu.be/8HfRSWrs5lM)
 
 ## Participants
 


### PR DESCRIPTION
it was just the Twitch link before, now it's the YouTube archive link